### PR TITLE
Read property testHome and resolve other files relative to this directory

### DIFF
--- a/src/main/java/org/icatproject/ids/storage_test/ArchiveFileStorage.java
+++ b/src/main/java/org/icatproject/ids/storage_test/ArchiveFileStorage.java
@@ -30,14 +30,21 @@ public class ArchiveFileStorage implements ArchiveStorageInterface {
 
 	private static Random rand = new Random();
 
+	Path testHome;
 	Path baseDir;
 
 	public ArchiveFileStorage(Properties props) throws IOException {
-		String fname = Utils.resolveEnvs(props.getProperty("plugin.archive.dir"));
+		String fname = props.getProperty("testHome");
+		if (fname == null) {
+			fname = System.getProperty("user.home");
+		}
+		testHome = Paths.get(fname);
+		Utils.checkDir(testHome);
+		fname = Utils.resolveEnvs(props.getProperty("plugin.archive.dir"));
 		if (fname == null) {
 			throw new IOException("\"plugin.archive.dir\" is not defined");
 		}
-		baseDir = new File(fname).toPath();
+		baseDir = testHome.resolve(fname);
 		Utils.checkDir(baseDir);
 	}
 
@@ -112,7 +119,7 @@ public class ArchiveFileStorage implements ArchiveStorageInterface {
 	}
 
 	private void think() throws IOException {
-		Path p = Paths.get(System.getProperty("user.home"), "reliability");
+		Path p = testHome.resolve("reliability");
 		try (BufferedReader in = Files.newBufferedReader(p)) {
 			double reliability = Double.parseDouble(in.readLine());
 			if (rand.nextFloat() > reliability) {

--- a/src/main/java/org/icatproject/ids/storage_test/MainFileStorage.java
+++ b/src/main/java/org/icatproject/ids/storage_test/MainFileStorage.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -21,14 +22,21 @@ import org.icatproject.ids.plugin.MainStorageInterface;
 
 public class MainFileStorage implements MainStorageInterface {
 
+	Path testHome;
 	Path baseDir;
 
 	public MainFileStorage(Properties props) throws IOException {
-		String fname = Utils.resolveEnvs(props.getProperty("plugin.main.dir"));
+		String fname = props.getProperty("testHome");
+		if (fname == null) {
+			fname = System.getProperty("user.home");
+		}
+		testHome = Paths.get(fname);
+		Utils.checkDir(testHome);
+		fname = Utils.resolveEnvs(props.getProperty("plugin.main.dir"));
 		if (fname == null) {
 			throw new IOException("\"plugin.main.dir\" is not defined");
 		}
-		baseDir = new File(fname).toPath();
+		baseDir = testHome.resolve(fname);
 		Utils.checkDir(baseDir);
 	}
 


### PR DESCRIPTION
Add a new property `testHome` to be read from the run.properties file.  This must be a directory.  It is optional and defaults to the home directory of the user running GlassFish.  The storage directories and the `reliability` file are resolved relative to this directory.  The storage directories may still be set to an absolute path.

This avoids hard coding the path of the `reliability` file and is needed to fix icatproject/ids.server#75.
